### PR TITLE
Corrected link for codeignition website.

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -115,7 +115,7 @@ page_id: home
     <a href="https://twitter.com/joshsoftware" class="twitter">Twitter</a>
   </li>
   <li>
-    <a href="http://codeignition.com/" target="_blank">
+    <a href="http://codeignition.co/" target="_blank">
       <%= image_tag "/images/sponsors/codeignition.png", :alt => "codeignition logo" %>
     </a>
     


### PR DESCRIPTION
From - http://codeignition.com
To - http://codeignition.co
