### PR TITLE
Trivandrum spelling correction

### DIFF
--- a/_includes/pages/community_in_india_index.html
+++ b/_includes/pages/community_in_india_index.html
@@ -12,5 +12,5 @@
   <li><a href="https://www.meetup.com/MumbaiRB/" target="_blank">Mumbai Ruby Users Group</a></li>
   <li><a href="https://www.meetup.com/mysore-ruby-meetup/" target="_blank">Mysore Ruby Users Group</a></li>
   <li><a href="https://www.meetup.com/PuneRailsMeetup/" target="_blank">Pune Ruby Users Group</a></li>
-  <li><a href="http://krug.github.io/posts/trivandrum-july" target="_blank">Trivendrum Ruby Users Group</a></li>
+  <li><a href="http://krug.github.io/posts/trivandrum-july" target="_blank">Trivandrum Ruby Users Group</a></li>
 </ul>


### PR DESCRIPTION
Trivandrum was spelled wrong under communities in India.
